### PR TITLE
fix: 修复 snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "command": "editor.action.insertSnippet",
         "when": "editorTextFocus && !editorHasSelection",
         "args": {
-          "snippet": "console.log('$1')$0"
+          "snippet": "console.log('[ $1 ]', $1)$0"
         },
         "key": "ctrl+l",
         "mac": "cmd+shift+l"


### PR DESCRIPTION
刚刚在写代码的过程中，使用 `<ctrl> + l` 快捷键，出来的却是 `console.log('')`。一开始我还以为是我又把配置搞混了，但我查找了半天也没有发现配置有什么问题。

于是就看看插件是不是更新了，一看果然更新了：
![image](https://user-images.githubusercontent.com/36906329/110085301-e5131c00-7dcb-11eb-98b9-ec4bdfb18ddd.png)

回滚到 `2.2.14` 这个版本就和以前一样了，没有啥问题。

于是跑来 github 来看看发生了什么事。

看到最近的 [提交](https://github.com/shangZhengXie/vscode-console-helper/commit/1a5d50cd59deeaeea4180fdf6b0f8d95aebbd59b) 中，发现了这个更改：
![image](https://user-images.githubusercontent.com/36906329/110085724-69659f00-7dcc-11eb-9624-3e46bea2de65.png)

想到可能是作者不小心写漏了，于是提交个 PR